### PR TITLE
fix typo in the documentation

### DIFF
--- a/_sources/detailed_notebooks/9. Reading and Writing from pgmpy file formats.ipynb.txt
+++ b/_sources/detailed_notebooks/9. Reading and Writing from pgmpy file formats.ipynb.txt
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can query this model accoring to our requirements. It is an instance of BayesianModel or MarkovModel depending on the type of the model which is given.\n",
+    "Now we can query this model according to our requirements. It is an instance of BayesianModel or MarkovModel depending on the type of the model which is given.\n",
     "\n",
     "Suppose we want to know all the nodes in the given model, we can do:"
    ]


### PR DESCRIPTION
I was reading the documentation and came across a very quick typo fix.